### PR TITLE
fix: force v2 peer endpoint

### DIFF
--- a/src/discovery.ts
+++ b/src/discovery.ts
@@ -67,7 +67,7 @@ export class PeerDiscovery {
 
 		const seed: IPeer = this.seeds[Math.floor(Math.random() * this.seeds.length)];
 
-		const { body } = await got.get(`http://${seed.ip}:${seed.port}/api/peers`, {
+		const { body } = await got.get(`http://${seed.ip}:${seed.port}/api/v2/peers`, {
 			...opts,
 			...{
 				headers: {


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://docs.ark.io/guidebook/contribution-guidelines/contributing.html
-->

v2.5 onwards of core defaults `/api/...` to v2, whereas pre-2.5 defaults to v1. This change forces v2 endpoints regardless of core version.

<!-- (Update "[ ]" to "[x]" to check a box) -->

## What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Performance
- [ ] Tests
- [ ] Build
- [ ] Documentation
- [ ] Code style update
- [ ] Continuous Integration
- [ ] Other, please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Does this PR release a new version?

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path for existing applications:

**The PR fulfills these requirements:**

- [ ] It's submitted to the `develop` branch, _not_ the `master` branch
- [ ] All tests are passing
- [ ] New/updated tests are included

If adding a **new feature**, the PR's description includes:

- [ ] A convincing reason for adding this feature (to avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it)
